### PR TITLE
Add support for PubMed IDs

### DIFF
--- a/tests/pubmed.t/run.t
+++ b/tests/pubmed.t/run.t
@@ -1,0 +1,15 @@
+Pubmed entry with 'PMC' prefix.
+  $ doi2bib PMC2883744
+  @article{Comas_2010,
+  	doi = {10.1038/ng.590},
+  	url = {https://doi.org/10.1038%2Fng.590},
+  	year = 2010,
+  	month = {may},
+  	publisher = {Springer Science and Business Media {LLC}},
+  	volume = {42},
+  	number = {6},
+  	pages = {498--503},
+  	author = {I{\~{n}}aki Comas and Jaidip Chakravartti and Peter M Small and James Galagan and Stefan Niemann and Kristin Kremer and Joel D Ernst and Sebastien Gagneux},
+  	title = {Human T cell epitopes of Mycobacterium tuberculosis are evolutionarily hyperconserved},
+  	journal = {Nature Genetics}
+  }


### PR DESCRIPTION
Hello,

This PR adds support for PubMed IDs.

Here is a usage example:
```bash
$ doi2bib PMC2883744
```
```
@article{Comas_2010,
        doi = {10.1038/ng.590},
        url = {https://doi.org/10.1038%2Fng.590},
        year = 2010,
        month = {may},
        publisher = {Springer Science and Business Media {LLC}},
        volume = {42},
        number = {6},
        pages = {498--503},
        author = {I{\~{n}}aki Comas and Jaidip Chakravartti and Peter M Small and James Galagan and Stefan Niemann and Kristin Kremer and Joel D Ernst and Sebastien Gagneux},
        title = {Human T cell epitopes of Mycobacterium tuberculosis are evolutionarily hyperconserved},
        journal = {Nature Genetics}
}%     
```

Closes #3 